### PR TITLE
Make SAFE easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ rm model.tar.gz
 ### 3. Use SAFE
 Please refer to this notebook [test.ipynb](test.ipynb)
 
+Or try out this script [test.py](test.py) to get all the function embeddings of the input binary.
+
+```bash
+python test.py <binary_path>
+```
 
 ## Acknowledgements
 * SAFE implementation in tensorflow (https://github.com/gadiluna/SAFE) 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,41 @@
+from utils.function_normalizer import FunctionNormalizer
+from utils.instructions_converter import InstructionsConverter
+from utils.capstone_disassembler import disassemble
+from utils.radare_analyzer import BinaryAnalyzer
+from safetorch.safe_network import SAFE
+from safetorch.parameters import Config
+import torch
+
+import sys
+
+binary_path = sys.argv[1]
+
+# initialize SAFE
+config = Config()
+safe = SAFE(config)
+
+# load instruction converter and normalizer
+I2V_FILENAME = "model/word2id.json"
+converter = InstructionsConverter(I2V_FILENAME)
+normalizer = FunctionNormalizer(max_instruction=150)
+
+# load SAFE weights
+SAFE_torch_model_path = "model/SAFEtorch.pt"
+state_dict = torch.load(SAFE_torch_model_path)
+safe.load_state_dict(state_dict)
+safe = safe.eval()
+
+# analyze the binary
+binary = BinaryAnalyzer(binary_path)
+offsets = binary.get_functions()
+
+# generate each function embedding
+for offset in offsets:
+    asm = binary.get_hexasm(offset)
+    instructions = disassemble(asm, binary.arch, binary.bits)
+    converted_instructions = converter.convert_to_ids(instructions)
+    instructions, length = normalizer.normalize_functions(
+        [converted_instructions])
+    tensor = torch.LongTensor(instructions[0])
+    function_embedding = safe(tensor, length)
+    print(hex(offset), function_embedding)

--- a/utils/radare_analyzer.py
+++ b/utils/radare_analyzer.py
@@ -1,0 +1,37 @@
+import r2pipe
+import json
+import sys
+
+
+class BinaryAnalyzer():
+    def __init__(self, path):
+        self.r2 = r2pipe.open(path, flags=["-2"])
+        self.r2.cmd("aaa")
+        self.arch = None
+        self.bits = None
+        try:
+            info = json.loads(self.r2.cmd("ij"))["bin"]
+            self.arch = info["arch"]
+            self.bits = info["bits"]
+        except:
+            print(f"Error loading file: {path}", file=sys.stderr)
+        try:
+            self.afl = self.r2.cmdj("aflj")
+        except:
+            self.afl = []
+
+    def get_hexasm(self, address):
+        data = filter(None, self.r2.cmd(f"pxf @ {address}").split("\n")[1:])
+        hexasm = ""
+        for i in data:
+            hexasm += "".join(i.split("  ")[1].split())
+        return hexasm
+
+    def get_functions(self):
+        offsets = set()
+        for f in self.afl:
+            offsets.add(f.get("offset", None))
+            for call in f.get("callrefs", []):
+                if call.get("type", None) == "CALL":
+                    offsets.add(call.get("addr", None))
+        return list(filter(None, offsets))


### PR DESCRIPTION
The test.ipynb notebook shows how to generate the function embedding with the piece of asm, but people may deal with the binary directly and use SAFE to get all the function embeddings. Therefore, I implement the utility and test script for reducing analysis effort.

Here is how I implemented it. I added Radare2 to parse the binary file and get the hex bytes to fit the input asm in the test.ipynb. While Radare2 can disassemble and extract instructions, I wanted to re-use the `disassemble` and `filter_memory_files` functions in `capstone_disassembler.py` to achieve minimal changes.

https://github.com/facebookresearch/SAFEtorch/commit/82d68e0541ddffdaf78ca32674c48e3a7285a493
- Add Radare2 to analyze the binary
- Extract all the function offsets
- Get function raw bytes in hex

https://github.com/facebookresearch/SAFEtorch/commit/7977bf22894dce1e66dc598f6aefa531bb5dd604
- Add test.py for generating all the function embeddings of the input binary

https://github.com/facebookresearch/SAFEtorch/commit/ffe3d1c9eb6b677334219ea8739e6d3f3b36cd54
- Add test.py usage in README.md